### PR TITLE
GtkPixbuf: implement gdk_pixbuf_new() and gdk_pixbuf_new_from_subpixbuf().

### DIFF
--- a/gdk-sys/src/lib.rs
+++ b/gdk-sys/src/lib.rs
@@ -512,17 +512,22 @@ extern "C" {
     //=========================================================================
     // GdkPixbuf                                                         NOT OK
     //=========================================================================
-    pub fn gdk_pixbuf_get_colorspace          (pixbuf: *const C_GdkPixbuf) -> enums::ColorSpace;
-    pub fn gdk_pixbuf_get_n_channels          (pixbuf: *const C_GdkPixbuf) -> c_int;
-    pub fn gdk_pixbuf_get_has_alpha           (pixbuf: *const C_GdkPixbuf) -> Gboolean;
-    pub fn gdk_pixbuf_get_bits_per_sample     (pixbuf: *const C_GdkPixbuf) -> c_int;
-    //pub fn gdk_pixbuf_get_pixels              (pixbuf: *const C_GdkPixbuf) -> *mut c_uchar;
-    pub fn gdk_pixbuf_get_pixels_with_length  (pixbuf: *const C_GdkPixbuf, length: *mut c_uint) -> *mut c_uchar;
-    pub fn gdk_pixbuf_get_width               (pixbuf: *const C_GdkPixbuf) -> c_int;
-    pub fn gdk_pixbuf_get_height              (pixbuf: *const C_GdkPixbuf) -> c_int;
-    pub fn gdk_pixbuf_get_rowstride           (pixbuf: *const C_GdkPixbuf) -> c_int;
-    pub fn gdk_pixbuf_get_byte_length         (pixbuf: *const C_GdkPixbuf) -> c_ulong;
-    pub fn gdk_pixbuf_get_option              (pixbuf: *const C_GdkPixbuf, key: *const c_char) -> *const c_char;
+    pub fn gdk_pixbuf_new(colorspace: enums::ColorSpace, has_alpha: Gboolean,
+        bits_per_sample: c_int, width: c_int, height: c_int) -> *mut C_GdkPixbuf;
+    pub fn gdk_pixbuf_new_from_subpixbuf(src_pixbuf: *mut C_GdkPixbuf, src_x: c_int, src_y: c_int,
+        width: c_int, height: c_int) -> *mut C_GdkPixbuf;
+    pub fn gdk_pixbuf_get_colorspace(pixbuf: *const C_GdkPixbuf) -> enums::ColorSpace;
+    pub fn gdk_pixbuf_get_n_channels(pixbuf: *const C_GdkPixbuf) -> c_int;
+    pub fn gdk_pixbuf_get_has_alpha(pixbuf: *const C_GdkPixbuf) -> Gboolean;
+    pub fn gdk_pixbuf_get_bits_per_sample(pixbuf: *const C_GdkPixbuf) -> c_int;
+    //pub fn gdk_pixbuf_get_pixels(pixbuf: *const C_GdkPixbuf) -> *mut c_uchar;
+    pub fn gdk_pixbuf_get_pixels_with_length(pixbuf: *const C_GdkPixbuf, length: *mut c_uint)
+        -> *mut c_uchar;
+    pub fn gdk_pixbuf_get_width(pixbuf: *const C_GdkPixbuf) -> c_int;
+    pub fn gdk_pixbuf_get_height(pixbuf: *const C_GdkPixbuf) -> c_int;
+    pub fn gdk_pixbuf_get_rowstride(pixbuf: *const C_GdkPixbuf) -> c_int;
+    pub fn gdk_pixbuf_get_byte_length(pixbuf: *const C_GdkPixbuf) -> c_ulong;
+    pub fn gdk_pixbuf_get_option(pixbuf: *const C_GdkPixbuf, key: *const c_char) -> *const c_char;
 
     //=========================================================================
     // GdkRectangle                                                      NOT OK

--- a/src/widgets/pixbuf.rs
+++ b/src/widgets/pixbuf.rs
@@ -15,6 +15,7 @@
 
 /// The GdkPixbuf structure contains information that describes an image in memory.
 
+use glib::to_gboolean;
 use glib::translate::{FromGlibPtr, ToGlibPtr};
 use ffi;
 use c_vec::CVec;
@@ -29,6 +30,24 @@ pub struct Pixbuf {
 }
 
 impl Pixbuf {
+    pub fn new(colorspace: ::ColorSpace, has_alpha: bool, bits_per_sample: i32, width: i32,
+            height: i32) -> Option<Pixbuf> {
+        match unsafe { ffi::gdk_pixbuf_new(colorspace, to_gboolean(has_alpha), bits_per_sample,
+                width, height) } {
+            pointer if !pointer.is_null() => Some(Pixbuf { pointer: pointer }),
+            _ => None
+        }
+    }
+
+    pub fn new_from_subpixbuf(&self, src_x: i32, src_y: i32, width: i32, height: i32) ->
+            Option<Pixbuf> {
+        match unsafe { ffi::gdk_pixbuf_new_from_subpixbuf(self.pointer, src_x, src_y, width,
+                height) } {
+            pointer if !pointer.is_null() => Some(Pixbuf { pointer: pointer }),
+            _ => None
+        }
+    }
+
     pub fn get_colorspace(&self) -> ::ColorSpace {
         unsafe { ffi::gdk_pixbuf_get_colorspace(self.pointer as *const ffi::C_GdkPixbuf) }
     }


### PR DESCRIPTION
Adds `gdk_pixbuf_new` and `gdk_pixbuf_new_from_subpixbuf` as shown in the [documentation](https://developer.gnome.org/gdk-pixbuf/2.22/gdk-pixbuf-creating.html) (cfr. issue rust-gnome/gtk#28). For the aforementioned issue `gdk_pixbuf_new_from_data` might be interesting as well, but that might be somewhat tricky to add because of the `GdkPixbufDestroyNotify`.

btw. the names in the commit should be: `GdkPixbuf`, `gdk_pixbuf_new` and `gdk_pixbuf_new_from_subpixbuf`, wasn't paying attention there.