### PR TITLE
GtkPixbuf: gdk_pixbuf_new_from_subpixbuf should be gdk_pixbuf_new_subpixbuf.

### DIFF
--- a/gdk-sys/src/lib.rs
+++ b/gdk-sys/src/lib.rs
@@ -514,7 +514,7 @@ extern "C" {
     //=========================================================================
     pub fn gdk_pixbuf_new(colorspace: enums::ColorSpace, has_alpha: Gboolean,
         bits_per_sample: c_int, width: c_int, height: c_int) -> *mut C_GdkPixbuf;
-    pub fn gdk_pixbuf_new_from_subpixbuf(src_pixbuf: *mut C_GdkPixbuf, src_x: c_int, src_y: c_int,
+    pub fn gdk_pixbuf_new_subpixbuf(src_pixbuf: *mut C_GdkPixbuf, src_x: c_int, src_y: c_int,
         width: c_int, height: c_int) -> *mut C_GdkPixbuf;
     pub fn gdk_pixbuf_get_colorspace(pixbuf: *const C_GdkPixbuf) -> enums::ColorSpace;
     pub fn gdk_pixbuf_get_n_channels(pixbuf: *const C_GdkPixbuf) -> c_int;

--- a/src/widgets/pixbuf.rs
+++ b/src/widgets/pixbuf.rs
@@ -39,10 +39,9 @@ impl Pixbuf {
         }
     }
 
-    pub fn new_from_subpixbuf(&self, src_x: i32, src_y: i32, width: i32, height: i32) ->
+    pub fn new_subpixbuf(&self, src_x: i32, src_y: i32, width: i32, height: i32) ->
             Option<Pixbuf> {
-        match unsafe { ffi::gdk_pixbuf_new_from_subpixbuf(self.pointer, src_x, src_y, width,
-                height) } {
+        match unsafe { ffi::gdk_pixbuf_new_subpixbuf(self.pointer, src_x, src_y, width, height) } {
             pointer if !pointer.is_null() => Some(Pixbuf { pointer: pointer }),
             _ => None
         }


### PR DESCRIPTION
This fixes a linking issue on Microsoft Windows, where it checks whether symbols exist during the linking phase, rather than run-time.