### PR TITLE
Adding functions for Pixbuf scaling

### DIFF
--- a/gdk-sys/src/enums.rs
+++ b/gdk-sys/src/enums.rs
@@ -606,6 +606,36 @@ pub enum DragAction {
     Ask
 }
 
+/// This enumeration describes the different interpolation modes that can be
+/// used with the scaling functions. `Nearest` is the fastest scaling method,
+/// but has horrible quality when scaling down. `Bilinear` is the best choice
+/// if you aren't sure what to choose, it has a good speed/quality balance.
+#[repr(C)]
+#[derive(Clone, PartialEq, PartialOrd, Debug, Copy)]
+pub enum InterpType {
+    /// Nearest neighbor sampling; this is the fastest and lowest quality mode.
+    /// Quality is normally unacceptable when scaling down, but may be OK when
+    /// scaling up.
+    Nearest,
+    /// This is an accurate simulation of the PostScript image operator without
+    /// any interpolation enabled. Each pixel is rendered as a tiny
+    /// parallelogram of solid color, the edges of which are implemented with
+    /// antialiasing. It resembles nearest neighbor for enlargement, and
+    /// bilinear for reduction.
+    Tiles,
+    /// Best quality/speed balance; use this mode by default. Bilinear
+    /// interpolation. For enlargement, it is equivalent to point-sampling the
+    /// ideal bilinear-interpolated image. For reduction, it is equivalent to
+    /// laying down small tiles and integrating over the coverage area.
+    Bilinear,
+    /// This is the slowest and highest quality reconstruction function. It is
+    /// derived from the hyperbolic filters in Wolberg's "Digital Image
+    /// Warping", and is formally defined as the hyperbolic-filter sampling the
+    /// ideal hyperbolic-filter interpolated image (the filter is designed to
+    /// be idempotent for 1:1 pixel mapping).
+    Hyper 
+}
+
 pub mod modifier_type {
     #![allow(non_upper_case_globals)]
 

--- a/gdk-sys/src/lib.rs
+++ b/gdk-sys/src/lib.rs
@@ -570,6 +570,14 @@ extern "C" {
     pub fn gdk_pixbuf_get_option(pixbuf: *const GdkPixbuf, key: *const c_char) -> *const c_char;
     pub fn gdk_pixbuf_get_type() -> GType;
 
+    pub fn gdk_pixbuf_scale_simple              (src: *const GdkPixbuf, dest_width: c_int, dest_height: c_int, interp_type: enums::InterpType) -> *mut GdkPixbuf;
+    pub fn gdk_pixbuf_scale                     (src: *const GdkPixbuf, dest: *mut GdkPixbuf, dest_x: c_int, dest_y: c_int, dest_width: c_int, dest_height: c_int, offset_x: c_double, offset_y: c_double, scale_x: c_double, scale_y: c_double, interp_type: enums::InterpType);
+    //pub fn gdk_pixbuf_composite_color_simple    (src: *const GdkPixbuf, dest_width: c_int, dest_height: c_int, interp_type: enums::InterpType, overall_alpha: c_int, check_size: c_int, color1: guint32, color2: guint32) -> *mut GdkPixbuf;
+    pub fn gdk_pixbuf_composite                 (src: *const GdkPixbuf, dest: *mut GdkPixbuf, dest_x: c_int, dest_y: c_int, dest_width: c_int, dest_height: c_int, offset_x: c_double, offset_y: c_double, scale_x: c_double, scale_y: c_double, interp_type: enums::InterpType, overall_alpha: c_int);
+    //pub fn gdk_pixbuf_composite_color           (src: *const GdkPixbuf, dest: *mut GdkPixbuf, dest_x: c_int, dest_y: c_int, dest_width: c_int, dest_height: c_int, offset_x: c_double, offset_y: c_double, scale_x: c_double, scale_y: c_double, interp_type: enums::InterpType, overall_alpha: c_int, check_x: c_int, check_y: c_int, check_size: c_int, color1: guint32, color2: guint32);
+    //pub fn gdk_pixbuf_rotate_simple             (src: *const GdkPixbuf, angle: GdkPixbufRotation) -> *mut GdkPixbuf;
+    pub fn gdk_pixbuf_flip                      (src: *const GdkPixbuf, horizontal: gboolean) -> *mut GdkPixbuf;
+
     //=========================================================================
     // GdkRectangle                                                      NOT OK
     //=========================================================================

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,7 @@ pub use gdk_ffi::enums::{
     Gravity,
     DragAction,
     DragProtocol,
-    InterpType
+    InterpType,
 };
 
 pub use self::keys::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,7 +139,8 @@ pub use gdk_ffi::enums::{
     WindowWindowClass,
     Gravity,
     DragAction,
-    DragProtocol
+    DragProtocol,
+    InterpType
 };
 
 pub use self::keys::{

--- a/src/pixbuf/mod.rs
+++ b/src/pixbuf/mod.rs
@@ -247,10 +247,11 @@ impl Pixbuf {
     }
 
     /// Flips a pixbuf horizontally or vertically and returns the result in a
-    /// new pixbuf, or `None` if not enough memory could be allocated for it.
-    pub fn flip(&self, horizontal: bool) -> Option<Pixbuf> {
+    /// new pixbuf, or `Err` if not enough memory could be allocated for it.
+    pub fn flip(&self, horizontal: bool) -> Result<Pixbuf, ()> {
         unsafe {
-            from_glib_none(ffi::gdk_pixbuf_flip(self.to_glib_none().0, horizontal.to_glib()))
+            Option::from_glib_full((ffi::gdk_pixbuf_flip(self.to_glib_none().0,
+                                                         horizontal.to_glib()))).ok_or(())
         }
     }
 

--- a/src/pixbuf/mod.rs
+++ b/src/pixbuf/mod.rs
@@ -195,9 +195,11 @@ impl Pixbuf {
     ///
     /// For more complicated scaling/compositing see `scale()` and
     /// `composite()`.
-    pub fn scale_simple(&self, dest_width: i32, dest_height: i32, interp_type: InterpType) -> Option<Pixbuf> {
+    pub fn scale_simple(&self, dest_width: i32, dest_height: i32, interp_type: InterpType)
+        -> Result<Pixbuf, ()> {
         unsafe {
-            from_glib_none(ffi::gdk_pixbuf_scale_simple(self.to_glib_none().0, dest_width, dest_height, interp_type))
+            Option::from_glib_full(ffi::gdk_pixbuf_scale_simple(self.to_glib_none().0, dest_width,
+                                                                dest_height, interp_type)).ok_or(())
         }
     }
 
@@ -214,9 +216,13 @@ impl Pixbuf {
     /// If the source rectangle overlaps the destination rectangle on the same
     /// pixbuf, it will be overwritten during the scaling which results in
     /// rendering artifacts.
-    pub fn scale(&self, dest: &Pixbuf, dest_x: i32, dest_y: i32, dest_width: i32, dest_height: i32, offset_x: f64, offset_y: f64, scale_x: f64, scale_y: f64, interp_type: InterpType) {
+    pub fn scale(&self, dest: &Pixbuf, dest_x: i32, dest_y: i32, dest_width: i32, dest_height: i32,
+                 offset_x: f64, offset_y: f64, scale_x: f64, scale_y: f64,
+                 interp_type: InterpType) {
         unsafe {
-            ffi::gdk_pixbuf_scale(self.to_glib_none().0, dest.to_glib_none().0, dest_x, dest_y, dest_width, dest_height, offset_x, offset_y, scale_x, scale_y, interp_type);
+            ffi::gdk_pixbuf_scale(self.to_glib_none().0, dest.to_glib_none().0, dest_x, dest_y,
+                                  dest_width, dest_height, offset_x, offset_y, scale_x, scale_y,
+                                  interp_type);
         }
     }
     
@@ -228,10 +234,15 @@ impl Pixbuf {
     /// 
     /// ![Diagram of `composite` process](https://developer.gnome.org/gdk-pixbuf/unstable/composite.png)
     ///
-    /// When the destination rectangle contains parts not in the source image, the data at the edges of the source image is replicated to infinity.
-    pub fn composite(&self, dest: &Pixbuf, dest_x: i32, dest_y: i32, dest_width: i32, dest_height: i32, offset_x: f64, offset_y: f64, scale_x: f64, scale_y: f64, interp_type: InterpType, overall_alpha: i32) {
+    /// When the destination rectangle contains parts not in the source image,
+    /// the data at the edges of the source image is replicated to infinity.
+    pub fn composite(&self, dest: &Pixbuf, dest_x: i32, dest_y: i32, dest_width: i32,
+                     dest_height: i32, offset_x: f64, offset_y: f64, scale_x: f64, scale_y: f64,
+                     interp_type: InterpType, overall_alpha: i32) {
         unsafe {
-            ffi::gdk_pixbuf_composite(self.to_glib_none().0, dest.to_glib_none().0, dest_x, dest_y, dest_width, dest_height, offset_x, offset_y, scale_x, scale_y, interp_type, overall_alpha);
+            ffi::gdk_pixbuf_composite(self.to_glib_none().0, dest.to_glib_none().0, dest_x, dest_y,
+                                      dest_width, dest_height, offset_x, offset_y, scale_x,
+                                      scale_y, interp_type, overall_alpha);
         }
     }
 

--- a/src/pixbuf/mod.rs
+++ b/src/pixbuf/mod.rs
@@ -14,6 +14,8 @@ use glib::{Error, to_gboolean, GlibContainer};
 use object::Object;
 use ffi;
 
+use {InterpType};
+
 pub mod animation;
 pub mod format;
 pub mod loader;
@@ -178,6 +180,66 @@ impl Pixbuf {
     pub fn get_option(&self, key: &str) -> Option<String> {
         unsafe {
             from_glib_none(ffi::gdk_pixbuf_get_option(self.to_glib_none().0, key.to_glib_none().0))
+        }
+    }
+
+    /// Create a new GdkPixbuf containing a copy of the current pixbuf scaled
+    /// to `dest_width` x `dest_height`. The calling pixbuf remains unaffected.
+    /// `interp_type` should be `Nearest` if you want maximum speed (but when
+    /// scaling down `Nearest` is usually unusably ugly). The default
+    /// `interp_type` should be `Bilinear` which offers reasonable quality and
+    /// speed.
+    ///
+    /// You can scale a sub-portion of `src` by creating a sub-pixbuf pointing
+    /// into src ; see `new_subpixbuf()`.
+    ///
+    /// For more complicated scaling/compositing see `scale()` and
+    /// `composite()`.
+    pub fn scale_simple(&self, dest_width: i32, dest_height: i32, interp_type: InterpType) -> Option<Pixbuf> {
+        unsafe {
+            from_glib_none(ffi::gdk_pixbuf_scale_simple(self.to_glib_none().0, dest_width, dest_height, interp_type))
+        }
+    }
+
+    /// Creates a transformation of the calling pixbuf by scaling by
+    /// `scale_x` and `scale_y` then translating by `offset_x` and `offset_y`,
+    /// then renders the rectangle (`dest_x`, `dest_y`, `dest_width`,
+    /// `dest_height`) of the resulting pixbuf onto the destination pixbuf,
+    /// replacing the previous contents.
+    ///
+    /// Try to use `scale_simple()` first; this function is the
+    /// industrial-strength power tool you can fall back to if `scale_simple()`
+    /// isn't powerful enough.
+    ///
+    /// If the source rectangle overlaps the destination rectangle on the same
+    /// pixbuf, it will be overwritten during the scaling which results in
+    /// rendering artifacts.
+    pub fn scale(&self, dest: &Pixbuf, dest_x: i32, dest_y: i32, dest_width: i32, dest_height: i32, offset_x: f64, offset_y: f64, scale_x: f64, scale_y: f64, interp_type: InterpType) {
+        unsafe {
+            ffi::gdk_pixbuf_scale(self.to_glib_none().0, dest.to_glib_none().0, dest_x, dest_y, dest_width, dest_height, offset_x, offset_y, scale_x, scale_y, interp_type);
+        }
+    }
+    
+    /// Creates a transformation of the calling pixbuf by scaling by `scale_x`
+    /// and `scale_y` then translating by `offset_x` and `offset_y`. This gives
+    /// an image in the coordinates of the destination pixbuf. The rectangle
+    /// (`dest_x`, `dest_y`, `dest_width`, `dest_height`) is then composited
+    /// onto the corresponding rectangle of the original destination image.
+    /// 
+    /// ![Diagram of `composite` process](https://developer.gnome.org/gdk-pixbuf/unstable/composite.png)
+    ///
+    /// When the destination rectangle contains parts not in the source image, the data at the edges of the source image is replicated to infinity.
+    pub fn composite(&self, dest: &Pixbuf, dest_x: i32, dest_y: i32, dest_width: i32, dest_height: i32, offset_x: f64, offset_y: f64, scale_x: f64, scale_y: f64, interp_type: InterpType, overall_alpha: i32) {
+        unsafe {
+            ffi::gdk_pixbuf_composite(self.to_glib_none().0, dest.to_glib_none().0, dest_x, dest_y, dest_width, dest_height, offset_x, offset_y, scale_x, scale_y, interp_type, overall_alpha);
+        }
+    }
+
+    /// Flips a pixbuf horizontally or vertically and returns the result in a
+    /// new pixbuf, or `None` if not enough memory could be allocated for it.
+    pub fn flip(&self, horizontal: bool) -> Option<Pixbuf> {
+        unsafe {
+            from_glib_none(ffi::gdk_pixbuf_flip(self.to_glib_none().0, horizontal.to_glib()))
         }
     }
 


### PR DESCRIPTION
Added functions for scaling `Pixbuf`s as described in "[Scaling](https://developer.gnome.org/gdk-pixbuf/unstable/gdk-pixbuf-Scaling.html)".