### PR TITLE
Replace features with cfg and automatic version detection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "gdk"
 version = "0.1.1"
 authors = ["The Rust-GNOME Project Developers"]
+build = "build.rs"
 
 description = "Rust bindings for the GDK library"
 repository = "https://github.com/rust-gnome/gdk"
@@ -17,13 +18,12 @@ keywords = ["gdk", "gtk", "gnome", "GUI"]
 name = "gdk"
 
 [features]
-default = ["gdk_3_6"]
-gdk_3_4 = ["gdk-sys/gdk_3_4"]
-gdk_3_6 = ["gdk-sys/gdk_3_6", "gdk_3_4"]
-gdk_3_8 = ["gdk-sys/gdk_3_8", "gdk_3_6"]
-gdk_3_10 = ["gdk-sys/gdk_3_10", "cairo-rs/cairo_1_12", "gdk_3_8"]
-gdk_3_12 = ["gdk-sys/gdk_3_12", "gdk_3_10"]
-gdk_3_14 = ["gdk-sys/gdk_3_14", "gdk_3_12"]
+gdk_3_4 = []
+gdk_3_6 = []
+gdk_3_8 = []
+gdk_3_10 = []
+gdk_3_12 = []
+gdk_3_14 = []
 
 [dependencies.gdk-sys]
 path = "gdk-sys"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,10 @@
+use std::env;
+
+fn main() {
+    let cfgs = env::var("OVERRIDE_GDK_CFG")
+        .or_else(|_| env::var("DEP_GDK_CFG"))
+        .unwrap_or_else(|e| panic!("Failed to read `DEP_GDK_CFG`: {}", e));
+    for cfg in cfgs.split(' ') {
+        println!("cargo:rustc-cfg={}", cfg);
+    }
+}

--- a/gdk-sys/Cargo.toml
+++ b/gdk-sys/Cargo.toml
@@ -16,14 +16,6 @@ keywords = ["gdk", "ffi", "gtk", "gnome"]
 [lib]
 name = "gdk_sys"
 
-[features]
-gdk_3_4 = []
-gdk_3_6 = ["gdk_3_4"]
-gdk_3_8 = ["gdk_3_6"]
-gdk_3_10 = ["gdk_3_8"]
-gdk_3_12 = ["gdk_3_10"]
-gdk_3_14 = ["gdk_3_12"]
-
 [dependencies.glib-sys]
 git  = "https://github.com/rust-gnome/glib"
 
@@ -35,4 +27,4 @@ bitflags = "0.1"
 libc = "0.1"
 
 [build-dependencies]
-pkg-config = "0.3"
+pkg-config = "0.3.5"

--- a/gdk-sys/build.rs
+++ b/gdk-sys/build.rs
@@ -1,8 +1,28 @@
 extern crate pkg_config;
 
+const MIN_MAJOR: u16 = 3;
+const MIN_MINOR: u16 = 4;
+const MINOR_STEP: u16 = 2;
+
 fn main() {
-    match pkg_config::find_library("gdk-3.0") {
-        Ok(_) => {},
-        Err(e) => panic!("{}", e)
-    };
+    let lib = pkg_config::find_library("gdk-3.0")
+        .unwrap_or_else(|e| panic!("{}", e));
+    let mut parts = lib.version.splitn(3, '.')
+        .map(|s| s.parse())
+        .take_while(|r| r.is_ok())
+        .map(|r| r.unwrap());
+    let version: (u16, u16) = (parts.next().unwrap_or(0), parts.next().unwrap_or(0));
+    let mut cfgs = Vec::new();
+    if version.0 == MIN_MAJOR && version.1 > MIN_MINOR {
+        let major = version.0;
+        let mut minor = MIN_MINOR + MINOR_STEP;
+        while minor <= version.1 {
+            cfgs.push(format!("gdk_{}_{}", major, minor));
+            minor += MINOR_STEP;
+        }
+    }
+    for cfg in &cfgs {
+        println!("cargo:rustc-cfg={}", cfg);
+    }
+    println!("cargo:cfg={}", cfgs.connect(" "));
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -236,7 +236,6 @@ impl Display {
     /// Currently this only works on X11 with XComposite and XDamage extensions available.
     ///
     /// Deprecated since GDK 3.16
-    #[cfg(not(gdk_3_16))]
     pub fn supports_composite(&self) -> bool {
         unsafe { from_glib(ffi::gdk_display_supports_composite(self.to_glib_none().0)) }
     }

--- a/src/display.rs
+++ b/src/display.rs
@@ -236,7 +236,7 @@ impl Display {
     /// Currently this only works on X11 with XComposite and XDamage extensions available.
     ///
     /// Deprecated since GDK 3.16
-    #[cfg(not(feature = "gdk_3_16"))]
+    #[cfg(not(gdk_3_16))]
     pub fn supports_composite(&self) -> bool {
         unsafe { from_glib(ffi::gdk_display_supports_composite(self.to_glib_none().0)) }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,9 +31,9 @@ pub mod device_manager;
 pub mod display;
 pub mod display_manager;
 pub mod drag_context;
-#[cfg(feature = "gdk_3_8")]
+#[cfg(gdk_3_8)]
 pub mod frame_clock;
-#[cfg(feature = "gdk_3_8")]
+#[cfg(gdk_3_8)]
 pub mod frame_timings;
 pub mod pixbuf;
 pub mod rgba;
@@ -61,7 +61,7 @@ pub use self::rt::{
     error_trap_pop,
     error_trap_pop_ignored
 };
-#[cfg(feature = "gdk_3_10")]
+#[cfg(gdk_3_10)]
 pub use self::rt::set_allowed_backends;
 
 pub use app_launch_context::AppLaunchContext;
@@ -72,9 +72,9 @@ pub use device_manager::DeviceManager;
 pub use display::Display;
 pub use display_manager::DisplayManager;
 pub use drag_context::DragContext;
-#[cfg(feature = "gdk_3_8")]
+#[cfg(gdk_3_8)]
 pub use frame_clock::FrameClock;
-#[cfg(feature = "gdk_3_8")]
+#[cfg(gdk_3_8)]
 pub use frame_timings::FrameTimings;
 pub use pixbuf::Pixbuf;
 pub use pixbuf::animation::PixbufAnimation;

--- a/src/pixbuf/animation.rs
+++ b/src/pixbuf/animation.rs
@@ -62,7 +62,7 @@ impl PixbufAnimation {
         }
     }
 
-    #[cfg(feature = "gdk_3_8")] // gdk-pixbuf 2.28
+    #[cfg(gdk_3_8)] // gdk-pixbuf 2.28
     pub fn new_from_resource(resource_path: &str) -> Result<PixbufAnimation, Error> {
         unsafe {
             let mut error = ptr::null_mut();

--- a/src/rt.rs
+++ b/src/rt.rs
@@ -36,7 +36,7 @@ pub fn notify_startup_complete_with_id(startup_id: &str) {
     }
 }
 
-#[cfg(feature = "gdk_3_10")]
+#[cfg(gdk_3_10)]
 pub fn set_allowed_backends(backends: &str) {
     unsafe {
         ffi::gdk_set_allowed_backends(backends.to_glib_none().0)

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -120,7 +120,7 @@ impl Screen {
         }
     }
 
-    #[cfg(feature = "gdk_3_10")]
+    #[cfg(gdk_3_10)]
     pub fn get_monitor_scale_factor(&self, monitor_num: i32) -> i32 {
         unsafe { ffi::gdk_screen_get_monitor_scale_factor(self.to_glib_none().0, monitor_num) }
     }

--- a/src/window.rs
+++ b/src/window.rs
@@ -13,7 +13,7 @@ use cairo;
 use cursor::Cursor;
 use device::Device;
 use display::Display;
-#[cfg(feature = "gdk_3_8")]
+#[cfg(gdk_3_8)]
 use frame_clock::FrameClock;
 use object::Object;
 use screen::Screen;
@@ -211,12 +211,12 @@ impl Window {
         unsafe { ffi::gdk_window_unfullscreen(self.to_glib_none().0) }
     }
 
-    #[cfg(feature = "gdk_3_8")]
+    #[cfg(gdk_3_8)]
     pub fn get_fullscreen_mode(&self) -> ::FullscreenMode {
         unsafe { ffi::gdk_window_get_fullscreen_mode(self.to_glib_none().0) }
     }
 
-    #[cfg(feature = "gdk_3_8")]
+    #[cfg(gdk_3_8)]
     pub fn set_fullscreen_mode(&self, mode: ::FullscreenMode) {
         unsafe { ffi::gdk_window_set_fullscreen_mode(self.to_glib_none().0, mode) }
     }
@@ -311,7 +311,7 @@ impl Window {
     /* FIXME : I think the Event struct is missing, not just a trait is needed:
     https://developer.gnome.org/gdk3/3.14/gdk3-Event-Structures.html#GdkEvent
 
-    #[cfg(feature = "gdk_3_14")]
+    #[cfg(gdk_3_14)]
     pub fn show_window_menu(&self, event: &::Event) {
         unsafe { ffi::gdk_window_show_window_menu(self.to_glib_none().0, event.to_glib_none().0) }
     }*/
@@ -327,7 +327,7 @@ impl Window {
         unsafe { ffi::gdk_window_beep(self.to_glib_none().0) }
     }
 
-    #[cfg(feature = "gdk_3_10")]
+    #[cfg(gdk_3_10)]
     pub fn get_scale_factor(&self) -> i32 {
         unsafe { ffi::gdk_window_get_scale_factor(self.to_glib_none().0) }
     }
@@ -364,7 +364,7 @@ impl Window {
         unsafe { ffi::gdk_window_set_debug_updates(setting.to_glib()) }
     }
 
-    #[cfg(feature = "gdk_3_8")]
+    #[cfg(gdk_3_8)]
     pub fn get_frame_clock(&self) -> FrameClock {
         unsafe { from_glib_none(ffi::gdk_window_get_frame_clock(self.to_glib_none().0)) }
     }
@@ -476,7 +476,7 @@ impl Window {
         unsafe { ffi::gdk_window_get_type_hint(self.to_glib_none().0) }
     }
 
-    #[cfg(feature = "gdk_3_12")]
+    #[cfg(gdk_3_12)]
     pub fn set_shadow_width(&self, left: i32, right: i32, top: i32, bottom: i32) {
         unsafe { ffi::gdk_window_set_shadow_width(self.to_glib_none().0, left, right, top,
             bottom) }
@@ -530,7 +530,7 @@ impl Window {
         }
     }
 
-    #[cfg(feature = "gdk_3_10")]
+    #[cfg(gdk_3_10)]
     pub fn get_device_position_double(&self, device: &Device, x: &mut f64, y: &mut f64,
         mask: &mut ::ModifierType) -> Option<Window> {
         unsafe {
@@ -654,12 +654,12 @@ impl Window {
         unsafe { ffi::gdk_window_set_source_events(self.to_glib_none().0, source, event_mask) }
     }
 
-    #[cfg(feature = "gdk_3_12")]
+    #[cfg(gdk_3_12)]
     pub fn get_event_compression(&self) -> bool {
         unsafe { from_glib(ffi::gdk_window_get_event_compression(self.to_glib_none().0)) }
     }
 
-    #[cfg(feature = "gdk_3_12")]
+    #[cfg(gdk_3_12)]
     pub fn set_event_compression(&self, event_compression: bool) {
         unsafe {
             ffi::gdk_window_set_event_compression(self.to_glib_none().0,


### PR DESCRIPTION
The user is no longer required to set the target library version, the builds script detects it from `pkg-config` output and sets the appropriate `cfg` directives.